### PR TITLE
Tweak: Add alternate variables for AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ npm install amazon-sp-api
 ## Getting Started
 Before you can use the client you need to add your app client and aws user credentials as environment variables:
 
-* SELLING_PARTNER_APP_CLIENT_ID=<YOUR_APP_CLIENT_ID> ([see SP Developer Guide "Viewing your developer information"](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/developer-guide/SellingPartnerApiDeveloperGuide.md#viewing-your-developer-information))
-* SELLING_PARTNER_APP_CLIENT_SECRET=<YOUR_APP_CLIENT_SECRET> ([see SP Developer Guide "Viewing your developer information"](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/developer-guide/SellingPartnerApiDeveloperGuide.md#viewing-your-developer-information))
-* AWS_ACCESS_KEY_ID=<YOUR_AWS_USER_ID> ([see SP Developer Guide "Create an IAM user"](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/developer-guide/SellingPartnerApiDeveloperGuide.md#step-2-create-an-iam-user))
-* AWS_SECRET_ACCESS_KEY=<YOUR_AWS_USER_SECRET> ([see SP Developer Guide "Create an IAM user"](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/developer-guide/SellingPartnerApiDeveloperGuide.md#step-2-create-an-iam-user))
-* AWS_SELLING_PARTNER_ROLE=<YOUR_AWS_SELLING_PARTNER_API_ROLE> ([see SP Developer Guide "Create an IAM role"](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/developer-guide/SellingPartnerApiDeveloperGuide.md#step-4-create-an-iam-role))
+* `SELLING_PARTNER_APP_CLIENT_ID`=<YOUR_APP_CLIENT_ID> ([see SP Developer Guide "Viewing your developer information"](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/developer-guide/SellingPartnerApiDeveloperGuide.md#viewing-your-developer-information))
+* `SELLING_PARTNER_APP_CLIENT_SECRET`=<YOUR_APP_CLIENT_SECRET> ([see SP Developer Guide "Viewing your developer information"](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/developer-guide/SellingPartnerApiDeveloperGuide.md#viewing-your-developer-information))
+* `AWS_SELLING_PARTNER_ACCESS_KEY_ID` or `AWS_ACCESS_KEY_ID`=<YOUR_AWS_USER_ID> ([see SP Developer Guide "Create an IAM user"](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/developer-guide/SellingPartnerApiDeveloperGuide.md#step-2-create-an-iam-user))
+* `AWS_SELLING_PARTNER_SECRET_ACCESS_KEY` or `AWS_SECRET_ACCESS_KEY`=<YOUR_AWS_USER_SECRET> ([see SP Developer Guide "Create an IAM user"](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/developer-guide/SellingPartnerApiDeveloperGuide.md#step-2-create-an-iam-user))
+* `AWS_SELLING_PARTNER_ROLE`=<YOUR_AWS_SELLING_PARTNER_API_ROLE> ([see SP Developer Guide "Create an IAM role"](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/developer-guide/SellingPartnerApiDeveloperGuide.md#step-4-create-an-iam-role))
 
 ### Setting credentials from file
 Instead of setting the credentials via environment variables you may load them from a credentials file. The default path to the file is ~/.amzspapi/credentials (path can be changed when creating a client) and you add the credentials one per line:

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -3,7 +3,13 @@ const fs = require('fs');
 const os = require('os');
 
 let credentials = {
-	keys:['SELLING_PARTNER_APP_CLIENT_ID', 'SELLING_PARTNER_APP_CLIENT_SECRET', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SELLING_PARTNER_ROLE'],
+	keys:[
+		['SELLING_PARTNER_APP_CLIENT_ID'],
+		['SELLING_PARTNER_APP_CLIENT_SECRET'],
+		['AWS_SELLING_PARTNER_ACCESS_KEY_ID', 'AWS_ACCESS_KEY_ID'],
+		['AWS_SELLING_PARTNER_SECRET_ACCESS_KEY', 'AWS_SECRET_ACCESS_KEY'],
+		['AWS_SELLING_PARTNER_ROLE']
+	],
 	getHomeDir:() => {
     let env = process.env;
     let home_dir = env.HOME || env.USERPROFILE || (env.HOMEPATH ? ((env.HOMEDRIVE || 'C:/') + env.HOMEPATH) : null);
@@ -23,20 +29,22 @@ let credentials = {
 		lines.forEach((line)=>{
 			let line_split = line.split('=');
 			let key = line_split[0].trim();
-			if (line_split.length === 2 && credentials.keys.includes(key)){
+			if (line_split.length === 2 && credentials.keys.some((keyOptions) => keyOptions.includes(key))){
 				found_credentials[key] = line_split[1].trim();
 			}
 		});
 		return found_credentials;
   },
   extractFromEnvVars:() => {
-  	let found_credentials = {};
-  	credentials.keys.forEach((key) => {
-      let value = process.env[key.trim()];
-      if (value){
-      	found_credentials[key.trim()] = value.trim();
-      }
-    });
+	let found_credentials = {};
+	credentials.keys.forEach(keyOptions => {
+		keyOptions.forEach((key) => {
+			let value = process.env[key.trim()];
+			if (value){
+				found_credentials[key.trim()] = value.trim();
+			}
+		});
+    })
     return found_credentials;
   },
   load:(path) => {
@@ -56,19 +64,21 @@ let credentials = {
 					secret:found_credentials['SELLING_PARTNER_APP_CLIENT_SECRET']
 				},
 				'aws_user':{
-					id:found_credentials['AWS_ACCESS_KEY_ID'],
-		      secret:found_credentials['AWS_SECRET_ACCESS_KEY'],
-		      role:found_credentials['AWS_SELLING_PARTNER_ROLE']
+					id:found_credentials['AWS_SELLING_PARTNER_ACCESS_KEY_ID'] || found_credentials['AWS_ACCESS_KEY_ID'],
+					secret:found_credentials['AWS_SELLING_PARTNER_SECRET_ACCESS_KEY'] || found_credentials['AWS_SECRET_ACCESS_KEY'],
+					role:found_credentials['AWS_SELLING_PARTNER_ROLE']
 				}
 			};
 		}
 
-		let missing_credentials = credentials.keys.filter((key) => {
-			return !Object.keys(found_credentials).includes(key);
+		let missing_credentials = credentials.keys.filter((keyOptions) => {
+			return !keyOptions.some(key => Object.keys(found_credentials).includes(key));
 		});
 		throw new CustomError({
   		code:'CREDENTIALS_MISSING',
-  		message:'Could not find the following credentials: ' + missing_credentials.join(',') 
+		message:'Could not find the following credentials: ' + missing_credentials
+			.map(keyOptions => keyOptions.join(' or '))
+			.join(',')
   	});
 	}
 };


### PR DESCRIPTION
In our production environment, we use Elastic Beanstalk. When we tried adding the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, it caused our aws-sdk to start using that key instead of authenticating with however Elastic Beanstalk does. Since Elastic Beanstalk does not set these variables and setting up a credentials file is not ideal for us, we'd like to see an alternative.

This PR adds alternate variable names for the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY for those running in environments where this is not easy to set. I have tested this locally by running all the tests using the environment variables in .env.test as well as setting up a file using credentials_path.