### PR TITLE
FIX: URL not defined in certain NodeJS versions

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,4 +1,5 @@
 const https = require('https');
+const { URL } = require('url');
 
 module.exports = (req_options) => {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
When testing this in local didn't any problem but on dev-server start throwing "URL not defined", some versions of NodeJS doesn't come with the same URL integration. 

#### Legacy API vs WHATWG URL API
> https://nodejs.org/api/url.html#url_url 

Declaring it fixes de issue.