### PR TITLE
Add sandbox mode

### DIFF
--- a/lib/SellingPartner.js
+++ b/lib/SellingPartner.js
@@ -20,6 +20,7 @@ class SellingPartner {
   // region:'eu', // Required: The region of the selling partner API endpoint ("eu", "na" or "fe")
   // refresh_token:'<YOUR_REFRESH_TOKEN>', // Required: The refresh token of your app user
   // access_token:'<YOUR_ACCESS_TOKEN>', // Optional: The access token requested with the refresh token of the app user
+  // sandbox:'true|false', // Optional: Sandbox mode, default : false
   // role_credentials:{ 
   //   id:'<YOUR_TEMPORARY_ROLE_ACCESS_ID>', // Optional: The temporary access id for the sp api role of the iam user
   //   secret:'<YOUR_TEMPORARY_ROLE_ACCESS_SECRET>', // Optional: The temporary access secret for the sp api role of the iam user
@@ -42,6 +43,11 @@ class SellingPartner {
         code:'NO_VALID_REGION_PROVIDED',
         message:'Please provide one of: "eu", "na" or "fe"'
       });
+    }
+    this._sandbox = config.sandbox ? true : false;
+    if (this._sandbox) {
+      console.log(' ==== SANDBOX MODE: ON ====')
+      console.log('More Info: https://github.com/amzn/selling-partner-api-docs/blob/main/guides/developer-guide/SellingPartnerApiDeveloperGuide.md#how-to-make-a-sandbox-call-to-the-selling-partner-api')
     }
     this._region = config.region;
     this._refresh_token = config.refresh_token;
@@ -258,7 +264,7 @@ class SellingPartner {
       });
     }
     req_params = operations[req_params.operation](req_params);
-    let signed_request = new Signer(this._region).signAPIRequest(this._access_token, this._role_credentials, req_params);
+    let signed_request = new Signer(this._region, this._sandbox).signAPIRequest(this._access_token, this._role_credentials, req_params);
     let res = await request(signed_request);
     let json_res;
     if (res.statusCode === 204 && req_params.method === 'DELETE'){
@@ -289,6 +295,12 @@ class SellingPartner {
       } else if (res.statusCode === 429 && error.code === 'QuotaExceeded' && this._options.auto_request_throttled){
         await this._wait(req_params.restore_rate);
         return await this.callAPI(req_params);
+      }
+      if (error && error.code && error.code === 'InternalFailure' && this._sandbox) {
+        throw new CustomError({
+          code: 'INVALID_SANDBOX_PARAMETERS',
+          message: 'You\'re in SANDBOX mode, make sure sandbox parameters are correct, as in Amazon SP API documentation: https://github.com/amzn/selling-partner-api-docs/blob/main/guides/developer-guide/SellingPartnerApiDeveloperGuide.md#how-to-make-a-sandbox-call-to-the-selling-partner-api'
+        });
       }
       throw new CustomError(error);
     }


### PR DESCRIPTION
Adding sandbox just enableing a internal variable _sandbox which is set by the config object passed by the constructor. 
This Variable is also passed when signing the request (so the url matches the requested one)
Also catching error when sandbox mode is on and error.code is 'InternalFailure' this means sandbox parameters are not correct.