### PR TITLE
Turn off quote detection in report csv to json conversion

### DIFF
--- a/lib/SellingPartner.js
+++ b/lib/SellingPartner.js
@@ -405,7 +405,8 @@ class SellingPartner {
           decrypted = xml_parser.parse(decrypted);
         } else if (res.headers['content-type'].includes('plain')){
           decrypted = await csv({
-            delimiter:'\t'
+            delimiter:'\t',
+            quote:'off'
           }).fromString(decrypted);
         }
       } catch(e){


### PR DESCRIPTION
One report didn't work for some reason, returning `quote_error` from csv conversion module. So i looked into report and found out one field name was starting with `"`, but wasnt ending with it, causing error. 

PR is an attempt at fixing it by turning off quote detection. Quotes in csv are used in cases when delimiter is used in field, for example if delimiter was `,` and you wanted to have comma in some field. I have tested failing report afterwards and it worked. I have manually checked multiple other reports with this fix and they all worked correctly, however that may not be the case for every report for every user. 