### PR TITLE
Fix Typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ let res = await sellingPartner.callAPI({
   }
 });
 ```
-In contrast, the implementation of the `getCatalogItem` operation in the `2021-12-01` version expects an `asin`, a `marketplaceIds` array and an `includedData` array as input:
+In contrast, the implementation of the `getCatalogItem` operation in the `2020-12-01` version expects an `asin`, a `marketplaceIds` array and an `includedData` array as input:
 ```javascript
 let res = await sellingPartner.callAPI({
   operation:'getCatalogItem',


### PR DESCRIPTION
Hi,
Thank you, for the amazing work you guys are doing.
I found a little typo in the readme, where it mentions the latest [catalog-items-api](https://github.com/amzn/selling-partner-api-docs/tree/main/references/catalog-items-api) version to be `2021-12-01` rather than  `2020-12-01`.