### PR TITLE
added upload typings for feeds

### DIFF
--- a/lib/typings/index.d.ts
+++ b/lib/typings/index.d.ts
@@ -131,6 +131,22 @@ declare module "amazon-sp-api" {
       details: ReportDocument,
       options?: DownloadOptions
     ): T;
+      
+    upload<T>(
+        details: {
+          url: string;
+          encryptionDetails?: {
+            key: string;
+            initializationVector: string;
+          };
+        },
+        feed: {
+          content?: string;
+          file?: string;
+          contentType?: string;
+        }
+      ): T;
+  
   }
 
   type Operation =


### PR DESCRIPTION
Good morning,

A few months ago I told you in an issue (https://github.com/amz-tools/amazon-sp-api/issues/59), if there were typings for upload functions.

I have created a basic one for feed upload, and it is tested under the feed API version 2021-06-30.

Regards.