### PR TITLE
added use_sandbox property to Options Type in : baseTypes.ts

### DIFF
--- a/lib/typings/baseTypes.ts
+++ b/lib/typings/baseTypes.ts
@@ -26,6 +26,7 @@ interface Options {
   auto_request_tokens?: boolean;
   auto_request_throttled?: boolean;
   only_grantless_operations?: boolean;
+  use_sandbox?: boolean;
 }
 
 export interface Config {


### PR DESCRIPTION
I was interested in TypeScript support for use_sandbox to be able to test sandbox mode in my typescript project  
so I added this type to the Options type of the constructor config 