### PR TITLE
Specifying custom user-agent headers for api calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ The class constructor takes a config object with the following structure as inpu
     auto_request_throttled:true,
     version_fallback:true,
     use_sandbox:false,
-    only_grantless_operations:false
+    only_grantless_operations:false,
+    user_agent: 'AppId/AppVersionId (Language=LanguageNameAndOptionallyVersion)'
   }
 }
 ```
@@ -148,6 +149,7 @@ Valid properties of the config options:
 | **version_fallback**<br>*optional* | boolean | true | Whether or not the client should try to use an older version of an endpoint if the operation is not defined for the desired version. |
 | **use_sandbox**<br>*optional* | boolean | false | Whether or not to use the sandbox endpoint. |
 | **only_grantless_operations**<br>*optional* | boolean | false | Whether or not to only use grantless operations. |
+| **user_agent**<br>*optional* | string | undefined | Custom User-Agent header for Selling Partner API calls. <a href='https://github.com/amzn/selling-partner-api-docs/blob/main/guides/en-US/developer-guide/SellingPartnerApiDeveloperGuide.md#include-a-user-agent-header-in-all-requests'>Click for details</a> |
 
 ### Exchange an authorization code for a refresh token
 If you already have a refresh token you can skip this step. If you only want to use the API for your own seller account you can just use the [self authorization](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/en-US/developer-guide/SellingPartnerApiDeveloperGuide.md#self-authorization) to obtain a valid refresh token.

--- a/lib/SellingPartner.js
+++ b/lib/SellingPartner.js
@@ -59,7 +59,8 @@ class SellingPartner {
       auto_request_throttled:true,
       use_sandbox:false,
       only_grantless_operations:false,
-      version_fallback:true
+      version_fallback:true,
+      user_agent: undefined
     }, config.options);
     this._endpoints_versions = this._validateEndpointsVersions(Object.assign({}, config.endpoints_versions));
     this._credentials = new Credentials(config.credentials, this._options.credentials_path).load();
@@ -525,7 +526,7 @@ class SellingPartner {
     } else if (req_params.restricted_data_token){
       token_for_request = req_params.restricted_data_token;
     }
-    let signed_request = new Signer(this._region, this._options.use_sandbox).signAPIRequest(token_for_request, this._role_credentials, req_params);
+    let signed_request = new Signer(this._region, this._options.use_sandbox, this._options.user_agent).signAPIRequest(token_for_request, this._role_credentials, req_params);
     let res = await request(signed_request);
     if (options.raw_result){
       return res;
@@ -541,7 +542,7 @@ class SellingPartner {
         code:'JSON_PARSE_ERROR',
         message:res.body
       });
-    } 
+    }
     if (json_res.errors){
       let error = json_res.errors[0];
       // Refresh tokens when expired and auto_request_tokens is true
@@ -572,12 +573,12 @@ class SellingPartner {
       }
       throw new CustomError(error);
     }
-    
+
     // If there is a pagination outside payload (like for getInventorySummaries), this will include it with the result
   	if (json_res.pagination && json_res.payload){
   		return Object.assign(json_res.pagination, json_res.payload);
-  	} 
-    
+  	}
+
     // Some calls do not return response in payload but directly (i.e. operation "getSmallAndLightEligibilityBySellerSKU")!
     return json_res.payload || json_res;
   }

--- a/lib/Signer.js
+++ b/lib/Signer.js
@@ -4,7 +4,7 @@ const utils = require('./utils');
 
 class Signer {
 
-  constructor(region, use_sandbox){
+  constructor(region, use_sandbox, user_agent){
     this._region = region;
     this._aws_regions = {
       'eu':'eu-west-1',
@@ -14,6 +14,7 @@ class Signer {
     let sandbox_prefix = use_sandbox ? 'sandbox.' : '';
     this._api_endpoint = sandbox_prefix + 'sellingpartnerapi-' + this._region + '.amazon.com';
     this._iso_date;
+    this._user_agent = user_agent
   }
 
   _createUTCISODate(){
@@ -127,7 +128,8 @@ class Signer {
         'host':this._api_endpoint,
         'x-amz-access-token':access_token,
         'x-amz-security-token':role_credentials.security_token,
-        'x-amz-date':this._iso_date.full
+        'x-amz-date':this._iso_date.full,
+        'user-agent': this._user_agent
       }
     };
 
@@ -164,7 +166,7 @@ class Signer {
     };
 
   }
-  
+
 };
 
 module.exports = Signer;

--- a/lib/typings/baseTypes.ts
+++ b/lib/typings/baseTypes.ts
@@ -27,6 +27,7 @@ interface Options {
   auto_request_throttled?: boolean;
   only_grantless_operations?: boolean;
   use_sandbox?: boolean;
+  user_agent?: string;
 }
 
 export interface Config {


### PR DESCRIPTION
This change allows to specify custom user-agent headers for api calls.

Since user-agent header is not mandatory, default value for "user-agent" is `undefined`, it means user-agent header won't be included to requests. 