### PR TITLE
double encoding fix for AWS Signature v4

### DIFF
--- a/lib/Signer.js
+++ b/lib/Signer.js
@@ -25,10 +25,9 @@ class Signer {
     };
   }
 
-  // Double encoding the api path will fix issues with path variables containing UTF-8 chars or whitespace (i.e. SKUs)
   _encodeApiPath(api_path){
     return api_path.split('/').map((url_part) => {
-      return utils.doubleEncodeURIComponent(url_part);
+      return utils.encodeURIComponent(url_part);
     }).join('/');
   }
 
@@ -74,7 +73,9 @@ class Signer {
   _constructCanonicalRequestForAPI(access_token, params, encoded_query_string){
     let canonical = [];
     canonical.push(params.method);
-    canonical.push(this._encodeApiPath(params.api_path));
+	  // URI components must be double encoded when constructing the canonical request
+	  // --> https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+    canonical.push(this._encodeApiPath(this._encodeApiPath(params.api_path)));
     canonical.push(encoded_query_string);
     canonical.push('host:' + this._api_endpoint);
     canonical.push('user-agent:' + this._user_agent);
@@ -104,7 +105,7 @@ class Signer {
   }
 
   _constructURL(req_params, encoded_query_string){
-    let url = 'https://' + this._api_endpoint + req_params.api_path;
+    let url = 'https://' + this._api_endpoint + this._encodeApiPath(req_params.api_path);
     if (encoded_query_string !== ''){
       url += '?' + encoded_query_string;
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,7 +33,7 @@ let utils = {
 	// URI components must be double encoded when constructing the canonical request
 	// --> https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
 	doubleEncodeURIComponent:(str) => {
-	  return utils.encodeSpecialChars(encodeURIComponent(encodeURIComponent(str)));
+	  return utils.encodeSpecialChars(encodeURIComponent(encodeURI(str)));
 	},
 	printWarning:{
 		'OPERATION_ONLY':() => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,11 +30,9 @@ let utils = {
 	    return '%' + c.charCodeAt(0).toString(16).toUpperCase();
 	  });
 	},
-	// URI components must be double encoded when constructing the canonical request
-	// --> https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
-	doubleEncodeURIComponent:(str) => {
-	  return utils.encodeSpecialChars(encodeURIComponent(encodeURI(str)));
-	},
+	encodeURIComponent:(str) => {
+		return utils.encodeSpecialChars(encodeURIComponent(str));
+	  },
 	printWarning:{
 		'OPERATION_ONLY':() => {
 			console.warn('WARNING! Calling an operation without an endpoint is deprecated and discouraged. You should specify an "endpoint" parameter or use shorthand dot notation (i.e. "catalogItems.getCatalogItem") as operation parameter value.');
@@ -50,6 +48,6 @@ let utils = {
 module.exports = {
 	checkParams:utils.checkParams,
 	encodeSpecialChars:utils.encodeSpecialChars,
-	doubleEncodeURIComponent:utils.doubleEncodeURIComponent,
+	encodeURIComponent:utils.encodeURIComponent,
 	warn:utils.warn
 };


### PR DESCRIPTION
While running productPricing.getListingOffers:

```
          const res = await sellingPartner.callAPI({
            operation: "productPricing.getListingOffers",
            path: {
              SellerSKU: "Merimieskirja+kynä",
            },
            query: {
              MarketplaceId: "ATVPDKIKX0DER",
              ItemCondition: "New",
            },
          });
```

The server responded with the following error:

```
error: Error: The request signature we calculated does not match the signature you provided. 
Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
The Canonical String for this request should have been
'GET/products/pricing/v0/listings/Merimieskirja%2Bkyn%25C3%25A4/offersItemCondition=New&MarketplaceId=ATVPDKIKX0DERhost:sellingpartnerapi-na.amazon.comuser-agent:amazon-sp-api/0.6.6 (Language=Node.js/v12.19.1; Platform=Linux/5.4.0-1057-aws
```

Looking into Signer.js in this package, the `canonical_request` that was generated began with:

```
GET
/products/pricing/v0/listings/Merimieskirja%252Bkyn%25C3%25A4/offers
ItemCondition=New&MarketplaceId=ATVPDKIKX0DER
```

When comparing the encoded SKUs side-by-side, it seems that the "+" sign has been encoded twice when it shouldn't've been:

```
Merimieskirja%252Bkyn%25C3%25A4 (Actual)
Merimieskirja%2Bkyn%25C3%25A4 (Expected by Amazon)
```

I've tested this against the `productPricing.getListingOffers` operation for a range of SKUs, including:

- ColorfulNotebook+McPen
- DiamondPens3+6
- Merimieskirja+kynä
- Erasable pens 6black + 6blue
- mcpens10in1usa
- Dotted Journal