### PR TITLE
comment out unused order types

### DIFF
--- a/lib/typings/operations/orders.ts
+++ b/lib/typings/operations/orders.ts
@@ -139,11 +139,14 @@ interface OrderItemBuyerInfoList{
     OrderItemBuyerInfo?: OrderItemBuyerInfo[];
 }
 
+// Unused type
+/*
 interface OrderItemsBuyerInfoList{
     OrderItems: OrderItemBuyerInfoList;
     NextToken?: string;
     AmazonOrderId: string;
 }
+*/
 
 interface OrderItem{
     ASIN: string;
@@ -184,11 +187,14 @@ interface OrderItemList{
     OrderItem?: OrderItem[];
 }
 
+// Unused type
+/*
 interface OrderItemsList{
     OrderItems: OrderItemList;
     NextToken?: string;
     AmazonOrderId?: string;
 }
+*/
 
 interface TaxClassification{
     Name?: string;


### PR DESCRIPTION
The unused typescript intefaces 'OrderItemsBuyerInfoList' and 'OrderItemsList' in `lib/typings/operations/orders.ts` break our git pipeline. I commented them out for now, until you need them.