### PR TITLE
Make amazon-sp-api compatible with bundler again

### DIFF
--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -1,16 +1,42 @@
 // For a list of required and optional body, query or path parameters for resources please see official references:
 // --> https://github.com/amzn/selling-partner-api-docs/tree/main/references
 
-const {readdirSync} = require('fs');
-const path = require('path');
-
 module.exports = {
-	...readdirSync(__dirname + '/resources').reduce((eps, ep) => {
-		if (path.extname(ep) === '.js'){
-			return Object.assign(eps, {
-				...require('./resources/' + ep)
-			});
-		}
-		return eps;
-	}, {})
+	...require('./resources/aplusContent'),
+	...require('./resources/authorization'),
+	...require('./resources/catalogItems'),
+	...require('./resources/fbaInboundEligibility'),
+	...require('./resources/fbaInventory'),
+	...require('./resources/fbaSmallAndLight'),
+	...require('./resources/feeds'),
+	...require('./resources/finances'),
+	...require('./resources/fulfillmentInbound'),
+	...require('./resources/fulfillmentOutbound'),
+	...require('./resources/listingsItems'),
+	...require('./resources/listingsRestrictions'),
+	...require('./resources/merchantFulfillment'),
+	...require('./resources/messaging'),
+	...require('./resources/notifications'),
+	...require('./resources/orders'),
+	...require('./resources/productFees'),
+	...require('./resources/productPricing'),
+	...require('./resources/productTypeDefinitions'),
+	...require('./resources/reports'),
+	...require('./resources/sales'),
+	...require('./resources/sellers'),
+	...require('./resources/services'),
+	...require('./resources/shipmentInvoicing'),
+	...require('./resources/shipping'),
+	...require('./resources/solicitations'),
+	...require('./resources/tokens'),
+	...require('./resources/uploads'),
+	...require('./resources/vendorDirectFulfillmentInventory'),
+	...require('./resources/vendorDirectFulfillmentOrders'),
+	...require('./resources/vendorDirectFulfillmentPayments'),
+	...require('./resources/vendorDirectFulfillmentShipping'),
+	...require('./resources/vendorDirectFulfillmentTransactions'),
+	...require('./resources/vendorInvoices'),
+	...require('./resources/vendorOrders'),
+	...require('./resources/vendorShipments'),
+	...require('./resources/vendorTransactionStatus'),
 };

--- a/lib/operations.js
+++ b/lib/operations.js
@@ -1,5 +1,5 @@
 // As the original design of the module (<= v0.3.7) didn't keep in mind the possibility of having more versions of the same endpoints
-// and as a result different versions of the same operation, we had to replace original operation-only based calls to the API 
+// and as a result different versions of the same operation, we had to replace original operation-only based calls to the API
 // with a new concept that includes endpoints and version-specific operation calls
 
 // In order to prevent breaking changes we need this operation to endpoint mapping
@@ -8,7 +8,7 @@ module.exports = (endpoints) => {
 	return {
 		...Object.keys(endpoints).reduce((eps, ep) => {
 			return Object.assign(eps, {
-				...require('./resources/' + ep)[ep].__operations.reduce((ops, op) => {ops[op] = ep; return ops;}, {})
+				...endpoints[ep].__operations.reduce((ops, op) => {ops[op] = ep; return ops;}, {})
 			});
 		}, {})
 	};


### PR DESCRIPTION
Hello,

I'm currently building an application that require a single javascript file as an entrypoint.
Problem is, since [this change](https://github.com/amz-tools/amazon-sp-api/commit/0bb9c6aed3957c6fd4f0ae3502c8462f13fa6e13), this is not possible anymore as the require process is dynamic.

As a result I get this error at runtime:

```
Error: ENOENT: no such file or directory, scandir '/workspace/connectors/amazon/build/cli/resources'
    at readdirSync (node:fs:1392:3)
    at null.../../node_modules/amazon-sp-api/lib/endpoints.js (/workspace/node_modules/amazon-sp-api/lib/endpoints.js:8:5)
    at __require (/workspace/connectors/amazon/build/cli/index.js:25:50)
    at null.../../node_modules/amazon-sp-api/lib/SellingPartner.js (/workspace/node_modules/amazon-sp-api/lib/SellingPartner.js:6:19)
    at __require (/workspace/connectors/amazon/build/cli/index.js:25:50)
    at null.../../node_modules/amazon-sp-api/index.js (/workspace/node_modules/amazon-sp-api/index.js:1:18)
    at __require (/workspace/connectors/amazon/build/cli/index.js:25:50)
    at Object.<anonymous> (/workspace/connectors/amazon/src/infrastructure/api-client/createClient.ts:1:31)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1155:10) {
```

As you can see, node tries to require javascript files that are not present in the build folder.

You can see similar issue on stack overflow [here](https://stackoverflow.com/questions/71503010/bundling-amazon-sp-api-with-webpack) when using webpack.

Since the change to a more dynamic import has been made, only one endpoint has been added to amazon-sp-api. So for me going back to a manual require will not be a huge pain so the trade off seems acceptable to me.

Let me know if I missed something.

Kind regards