### PR TITLE
Added catalogItems endpoint 2022-04-01 version

### DIFF
--- a/lib/resources/catalogItems.js
+++ b/lib/resources/catalogItems.js
@@ -2,7 +2,8 @@ module.exports = {
   catalogItems:{
     __versions:[
     	'v0',
-    	'2020-12-01'
+    	'2020-12-01',
+      "2022-04-01"
   	],
     __operations:[
     	'listCatalogItems',
@@ -11,6 +12,7 @@ module.exports = {
       'searchCatalogItems'
   	],
     ...require('./versions/catalog_items/catalogItems_v0'),
-    ...require('./versions/catalog_items/catalogItems_2020-12-01')
+    ...require('./versions/catalog_items/catalogItems_2020-12-01'),
+    ...require('./versions/catalog_items/catalogItems_2022-04-01')
   }
 };

--- a/lib/resources/versions/catalog_items/catalogItems_2022-04-01.js
+++ b/lib/resources/versions/catalog_items/catalogItems_2022-04-01.js
@@ -1,0 +1,27 @@
+const utils = require('../../../utils');
+
+module.exports = {
+  '2022-04-01':{
+    searchCatalogItems:(req_params) => {
+      return Object.assign(req_params, {
+        method:'GET',
+        api_path:'/catalog/2022-04-01/items',
+        restore_rate:0.2
+      });
+    },
+    getCatalogItem:(req_params) => {
+    	req_params = utils.checkAndEncodeParams(req_params, {
+    	  path:{
+          asin:{
+            type:'string'
+          }
+        }
+  	  });
+      return Object.assign(req_params, {
+        method:'GET',
+        api_path:'/catalog/2022-04-01/items/' + req_params.path.asin,
+        restore_rate:0.2
+      });
+    }
+  }
+};

--- a/test/specs/operations/catalogItems.spec.js
+++ b/test/specs/operations/catalogItems.spec.js
@@ -134,4 +134,41 @@ describe(endpoint, async function(){
     expect(res.Items).to.be.a('array');
   });
 
+  it('should return a catalog item (2022-04-01) for SKU', async function(){
+    let res = await this.sellingPartner.callAPI({
+      operation:'searchCatalogItems',
+      endpoint:endpoint,
+      query:{
+        identifiers: [this.config.sku],
+        identifiersType: "SKU",
+        marketplaceIds:[this.config.marketplace_id],
+        sellerId: this.config.seller_id,
+        includedData:['images']
+      },
+      options:{
+        version:'2022-04-01'
+      }
+    });
+    expect(res).to.be.a('object');
+    expect(res.items[0].asin).to.be.a('string');
+  });
+
+  it('should return a catalog item (2022-04-01)', async function(){
+    let res = await this.sellingPartner.callAPI({
+      operation:'getCatalogItem',
+      endpoint:endpoint,
+      path:{
+        asin:this.config.asin
+      },
+      query:{
+        marketplaceIds: [this.config.marketplace_id]
+      },
+      options:{
+        version:'2022-04-01'
+      }
+    });
+    console.log("res", res)
+    expect(res).to.be.a('object');
+    expect(res.asin).to.be.a('string');
+	});
 });

--- a/test/specs/operations/catalogItems.spec.js
+++ b/test/specs/operations/catalogItems.spec.js
@@ -41,7 +41,7 @@ describe(endpoint, async function(){
         asin:this.config.asin
       },
       query:{
-        marketplaceIds:['A1PA6795UKMFR9'],
+        marketplaceIds:[this.config.marketplace_id],
         includedData:['identifiers', 'images', 'productTypes', 'salesRanks', 'summaries', 'variations']
       },
       options:{
@@ -167,7 +167,6 @@ describe(endpoint, async function(){
         version:'2022-04-01'
       }
     });
-    console.log("res", res)
     expect(res).to.be.a('object');
     expect(res.asin).to.be.a('string');
 	});


### PR DESCRIPTION
[New version of Catalog Items API](https://github.com/amzn/selling-partner-api-docs/discussions/2289)

This is the latest document  [URL](https://developer-docs.amazon.com/sp-api/docs/catalog-items-api-v2022-04-01-reference#getcatalogitem)
