### PR TITLE
Add encode query twice option fix #134

### DIFF
--- a/lib/Signer.js
+++ b/lib/Signer.js
@@ -31,11 +31,13 @@ class Signer {
     }).join('/');
   }
 
-  _constructEncodedQueryString(query){
+  _constructEncodedQueryString(query, to_encode_twice = false){
     if (query){
-      let key_is_sku = false;
       return qs.stringify(query, {
         encoder:(value, defaultEncoder, charset, type) => {
+          if (to_encode_twice) {
+            return utils.encodeURIComponent(utils.encodeURIComponent(value));
+          }
           return utils.encodeURIComponent(value);
         },
         arrayFormat:'comma',
@@ -110,7 +112,7 @@ class Signer {
 
     this._createUTCISODate();
 
-    let encoded_query_string = this._constructEncodedQueryString(req_params.query);
+    let encoded_query_string = this._constructEncodedQueryString(req_params.query, req_params.to_encode_query_twice ?? flase);
     let canonical_request = this._constructCanonicalRequestForAPI(access_token, req_params, encoded_query_string);
     let string_to_sign = this._constructStringToSign(this._aws_regions[this._region], 'execute-api', canonical_request);
     let signature = this._constructSignature(this._aws_regions[this._region], 'execute-api', string_to_sign, role_credentials.secret);

--- a/lib/resources/versions/product_pricing/productPricing_v0.js
+++ b/lib/resources/versions/product_pricing/productPricing_v0.js
@@ -6,7 +6,8 @@ module.exports = {
       return Object.assign(req_params, {
         method:'GET',
         api_path:'/products/pricing/v0/price',
-        restore_rate:0.1
+        restore_rate:0.1,
+        to_encode_query_twice: true
       });
     },
     getCompetitivePricing:(req_params) => {


### PR DESCRIPTION
Regarding [issue #134](https://github.com/amz-tools/amazon-sp-api/issues/134)
It takes Amazon pretty long to reply. Let's have an update so meanwhile everything works properly.

I added a parameter `to_encode_query_twice` that you can include for any query you notice the same problem with double encoding. When Amazon fixes it, we can just remove the parameter from a specific endpoint that got fixed.