### PR TITLE
query params bugfix

### DIFF
--- a/lib/Signer.js
+++ b/lib/Signer.js
@@ -110,6 +110,7 @@ class Signer {
     this._createUTCISODate();
 
     let encoded_query_string = this._constructEncodedQueryString(req_params.query, req_params.encode_twice);
+    encoded_query_string = encoded_query_string.replace("MarketplaceIds%5B%5D", "MarketplaceIds")
     let canonical_request = this._constructCanonicalRequestForAPI(access_token, req_params, encoded_query_string);
     let string_to_sign = this._constructStringToSign(this._aws_regions[this._region], 'execute-api', canonical_request);
     let signature = this._constructSignature(this._aws_regions[this._region], 'execute-api', string_to_sign, role_credentials.secret);


### PR DESCRIPTION
Hello fellas, we are using this useful package but we've noticed when we pass query params as 
```
query: {
        MarketplaceIds: ["ATVPDKIKX0DER"],
        CreatedAfter: "2022-06-14T15:00:00-07:00",
},
```
created request generated as "https://sellingpartnerapi-na.amazon.com/orders/v0/orders?CreatedAfter=2022-06-01T00%3A00%3A00-07%3A00&MarketplaceIds%5B%5D=ATVPDKIKX0DER"  so amazon api raises error missing MarketplaceIds. I know this is not a reliable solution but it will hold until the next update.