### PR TITLE
Added response timeout and deadline timeout option support

### DIFF
--- a/lib/Signer.js
+++ b/lib/Signer.js
@@ -131,7 +131,9 @@ class Signer {
         'x-amz-access-token':access_token,
         'x-amz-security-token':role_credentials.security_token,
         'x-amz-date':this._iso_date.full     
-      }
+      },
+      response_timeout: req_params.options.response_timeout ? req_params.options.response_timeout : null,
+      deadline_timeout: req_params.options.deadline_timeout ? req_params.options.deadline_timeout : null
     };
 
   }

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,3 +1,4 @@
+const CustomError = require('./CustomError');
 const https = require('https');
 const { URL } = require('url');
 
@@ -16,14 +17,41 @@ module.exports = (req_options) => {
       post_params = req_options.body;
       options.headers['Content-Length'] = Buffer.byteLength(post_params);
     }
+
+    // Set up timeouts if set in request options; destroy request & reject with error if exceeded
+    //  - response timeout is time between sending request and receiving the first byte of the response. Includes DNS and connection time.
+	//  - deadline is the time from start of the request to receiving response body in full. If the deadline is too short large files may not load at all on slow connections.
+    let response_timeout_id = null;
+    if (req_options.response_timeout) response_timeout_id = setTimeout(() => {   	
+		req.destroy(new CustomError({	// req.destroy will cause an error event to be emitted, rejection is handled in error event handler
+			code:'API_RESPONSE_TIMEOUT',
+			message:'No data received within specified response timeout (' + req_options.response_timeout + 'ms).',
+			timeout: req_options.response_timeout
+		}));
+    },req_options.response_timeout);   
+    let deadline_timeout_id = null;
+    if (req_options.deadline_timeout) deadline_timeout_id = setTimeout(() => {   	
+		req.destroy(new CustomError({	// req.destroy will cause an error event to be emitted, rejection is handled in error event handler
+			code:'API_DEADLINE_TIMEOUT',
+			message:'Response was not completely received within specified deadline (' + req_options.deadline_timeout + 'ms).',
+			timeout: req_options.deadline_timeout
+		}));
+    },req_options.deadline_timeout);
+ 
     let req = https.request(options, (res) => {
       let chunks = [];
       let body = '';
+      let response_started = false;
       res.on('data', (chunk) => {
+      	if(!response_started && response_timeout_id) {
+      		 clearTimeout(response_timeout_id);
+      		 response_started = true;
+      	}
         body += chunk;
         chunks.push(chunk);
       });
       res.on('end', () => {
+      	if(deadline_timeout_id) clearTimeout(deadline_timeout_id);
         resolve({
           body:body,
           chunks:chunks,


### PR DESCRIPTION
Allows request to be aborted if it takes a lot longer than expected due to network errors.

Enabled by setting `options.request_timeout` and / or `options.deadline_timeout`; if these options are not set, the original behaviour (no timeout) is preserved. Sample code and description of options added to README.

resolves #147 