### PR TITLE
Fix CreateReportResponse TypeScript Interface

### DIFF
--- a/lib/typings/operations/reports.ts
+++ b/lib/typings/operations/reports.ts
@@ -1,9 +1,7 @@
 import { BaseResponse, ProcessingStatus } from "../baseTypes";
 
 export interface CreateReportResponse extends BaseResponse {
-  payload?: {
-    reportId: string;
-  };
+  reportId: string;
 }
 
 export interface GetReportPath {


### PR DESCRIPTION
This PR is to update the interface CreateReportResponse to reflect that change in the function as it now unwraps the payload object by default.