### PR TITLE
fix(named-exports): instead of `export default`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,18 +82,22 @@ Although the most convenient and recommended way of setting the credentials is v
 
 Require library:
 ```javascript
-const SellingPartnerAPI = require('amazon-sp-api');
+// commonjs
+const SellingPartner = require('amazon-sp-api');
+
+// ems
+import { SellingParner } from 'amazon-sp-api';
 ```
 
 Create client and call API:
 ```javascript
 (async() => {
   try {
-    let sellingPartner = new SellingPartnerAPI({
+    let sellingPartnerInstance = new SellingPartner({
       region:'eu', // The region to use for the SP-API endpoints ("eu", "na" or "fe")
       refresh_token:'<REFRESH_TOKEN>' // The refresh token of your app user
     });
-    let res = await sellingPartner.callAPI({
+    let res = await sellingPartnerInstance.callAPI({
       operation:'getMarketplaceParticipations',
       endpoint:'sellers'
     });

--- a/lib/SellingPartner.js
+++ b/lib/SellingPartner.js
@@ -767,4 +767,4 @@ class SellingPartner {
 
 };
 
-module.exports = SellingPartner;
+module.exports = { SellingPartner };

--- a/lib/typings/index.d.ts
+++ b/lib/typings/index.d.ts
@@ -134,7 +134,7 @@ import { IReqOptions } from './IReqOptions'
 import { ReportDocumentType } from './download'
 
 declare module 'amazon-sp-api' {
-  export default class SellingPartner {
+  export class SellingPartner {
     constructor(config: Config)
 
     refreshAccessToken(): Promise<void>


### PR DESCRIPTION
This seems to fix the #141  (also types are working after this change)
If its ok, the docs need to be fixed and normalized for the new export name