### PR TITLE
Export all types for fbaInventory and update getInventorySummariesRes…

### DIFF
--- a/lib/typings/operations/fbaInventory.ts
+++ b/lib/typings/operations/fbaInventory.ts
@@ -1,4 +1,4 @@
-import { BaseResponse, Pagination } from "../baseTypes";
+import { BaseResponse } from "../baseTypes";
 
 type GranularityType = "Marketplace";
 
@@ -13,21 +13,16 @@ export interface GetInventorySummariesQuery {
 }
 
 export interface GetInventorySummariesResponse extends BaseResponse {
-  payload?: GetInventorySummariesResult;
-  pagination: Pagination;
+  granularity?: Granularity;
+  inventorySummaries?: InventorySummary[];
+  nextToken?: string;
 }
-
-interface GetInventorySummariesResult {
-  granularity: Granularity;
-  inventorySummaries: InventorySummary[];
-}
-
-interface Granularity {
+export interface Granularity {
   granularityType?: GranularityType;
   granularityId?: string;
 }
 
-interface InventorySummary {
+export interface InventorySummary {
   asin?: string;
   fnSku?: string;
   sellerSku?: string;
@@ -38,7 +33,7 @@ interface InventorySummary {
   totalQuantity?: number;
 }
 
-interface InventoryDetails {
+export interface InventoryDetails {
   fulfillableQuantity?: number;
   inboundWorkingQuantity?: number;
   inboundShippedQuantity?: number;
@@ -48,19 +43,19 @@ interface InventoryDetails {
   unfulfillableQuantity?: UnfulfillableQuantity;
 }
 
-interface ReservedQuantity {
+export interface ReservedQuantity {
   totalReservedQuantity?: number;
   pendingCustomerOrderQuantity?: number;
   pendingTransshipmentQuantity?: number;
   fcProcessingQuantity?: number;
 }
 
-interface ResearchingQuantity {
+export interface ResearchingQuantity {
   totalResearchingQuantity?: number;
   researchingQuantityBreakdown?: ResearchingQuantityEntry[];
 }
 
-interface ResearchingQuantityEntry {
+export interface ResearchingQuantityEntry {
   name: Name;
   quantity: number;
 }
@@ -70,7 +65,7 @@ type Name =
   | "researchingQuantityInMidTerm"
   | "researchingQuantityInLongTerm";
 
-interface UnfulfillableQuantity {
+export interface UnfulfillableQuantity {
   totalUnfulfillableQuantity?: number;
   customerDamagedQuantity?: number;
   warehouseDamagedQuantity?: number;


### PR DESCRIPTION
…ponse type to match

- Exports all interfaces for fbaInventory namespace so that consumers can use interfaces outside of the GetInventorySummariesResponse/Query interfaces
- Updates the GetInventorySummariesResponse interface to match actual payload (fixes https://github.com/amz-tools/amazon-sp-api/issues/128) 