### PR TITLE
Add support for createReport types

### DIFF
--- a/lib/typings/index.d.ts
+++ b/lib/typings/index.d.ts
@@ -324,6 +324,8 @@ declare module 'amazon-sp-api' {
     ? GetItemOffersResponse
     : TOperation extends "productPricing.getItemOffers"
     ? GetItemOffersResponse
+    : TOperation extends "createReport"
+    ? CreateReportResponse
     : any;
 
   type QueryType<TOperation extends Operation> =


### PR DESCRIPTION
Currently if I do:
```ts
sellingPartner.callAPI({
      body: {
        // body
      },
      operation: 'createReport'
    });
```
There is no type inference. Fixed this issue