### PR TITLE
Fixes empty errors array handling in call api method

### DIFF
--- a/lib/SellingPartner.js
+++ b/lib/SellingPartner.js
@@ -664,7 +664,7 @@ class SellingPartner {
         message:res.body
       });
     }
-    if (json_res.errors){
+    if (json_res.errors && json_res.errors.length){
       let error = json_res.errors[0];
       // Refresh tokens when expired and auto_request_tokens is true
       if (res.statusCode === 403){


### PR DESCRIPTION
Fixes the the bug in condition that checks for errors in callAPI method response, that lead to treating empty errors array as having an error.