### PR TITLE
204 statusCode parsing bug

### DIFF
--- a/lib/SellingPartner.js
+++ b/lib/SellingPartner.js
@@ -627,7 +627,7 @@ class SellingPartner {
     if (options.raw_result) {
       return res;
     }
-    if (res.statusCode === 204 && req_params.method === "DELETE") {
+    if (res.statusCode === 204) {
       return { success: true };
     }
     let json_res;


### PR DESCRIPTION
should solve the 204 statusCode parsing bug #259 

We can also add a new guard to match a 204 response && method !== 'DELETE' and return `null`
This should be closer to amazon response
```js
  if (res.statusCode === 204 && req_params.method === "DELETE") {
      return { success: true };
    }
  if (res.statusCode === 204 && req_params.method !== "DELETE") {
      return null;
    }

```