### PR TITLE
Added an option to use a custom proxy agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The client handles calls to the Amazon Selling Partner API. It wraps up all the 
   - [Setting credentials from constructor config object](#setting-credentials-from-constructor-config-object)
 - [Usage](#usage)
   - [Config params](#config-params)
+  - [Use a proxy agent](#use-a-proxy-agent)
   - [Exchange an authorization code for a refresh token](#exchange-an-authorization-code-for-a-refresh-token)
   - [Request access token](#request-access-token)
 - [Call the API](#call-the-api)
@@ -132,7 +133,8 @@ The class constructor takes a config object with the following structure as inpu
     timeouts:{
       ...
     },
-    retry_remote_timeout:true
+    retry_remote_timeout:true,
+	  httpsProxyAgent: new https.Agent()
   }
 }
 ```
@@ -162,6 +164,22 @@ Valid properties of the config options:
 | **debug_log**<br>_optional_                 | boolean |                                                 false                                                 | Whether or not the client should print console logs for debugging purposes.                                                                                    |
 | **timeouts**<br>_optional_                  | object  |                                                   -                                                   | Allows to set timeouts for requests. Valid keys are `response`, `idle` and `deadline`. Please see detailed information in the [Timeouts](#timeouts) section.   |
 | **retry_remote_timeout**<br>_optional_      | boolean |                                                 true                                                  | Whether or not the client should retry a request to the remote server that failed with an ETIMEDOUT error                                                      |
+| **httpsProxyAgent**<br>_optional_      | object |                                                 https.Agent()                                                  | Override NodeJS [default https agent](https://nodejs.org/api/https.html#class-httpsagent).  Please see detailed information in the [Using Proxy Agent](#use-a-proxy-agent) section.                                                     |
+
+### Use a proxy agent
+
+If you are behing a firewall and would like to use a proxy server then you can pass a custom proxy agent which will override the [default https agent](https://nodejs.org/api/https.html#class-httpsagent) of NodeJS.
+
+```javascript
+const { HttpsProxyAgent } = require('hpagent');
+const agent = new HttpsProxyAgent({ proxy: 'http://x.x.x.x:zzzz' });
+const spClient = new SellingPartner({
+  region: "eu",
+  options: {
+    httpsProxyAgent: agent
+  }
+});
+```
 
 ### Exchange an authorization code for a refresh token
 

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -115,7 +115,8 @@ class Request {
         port: 443,
         hostname: url.hostname,
         path: url.pathname + url.search,
-        headers: req_options.headers || {}
+        headers: req_options.headers || {},
+        agent:this._options.httpsProxyAgent
       };
 
       let post_params;

--- a/lib/SellingPartner.js
+++ b/lib/SellingPartner.js
@@ -11,6 +11,7 @@ const iconv = require("iconv-lite");
 const client_version = require("../package.json").version;
 const node_version = process.version;
 const os = require("os");
+const https = require("https");
 
 // Provide credentials as environment variables OR create a path and file ~/.amzspapi/credentials (located in your user folder)
 // If you don't provide an access_token, the first call to an API endpoint will request them with a TTL of 1 hour
@@ -44,6 +45,7 @@ class SellingPartner {
   //     deadline:0 // Optional: The time in milliseconds until a deadline timeout is fired (time between starting the request and receiving the full response).
   //   },
   //   retry_remote_timeout:true // Optional: Whether or not the client should retry a request to the remote server that failed with an ETIMEDOUT error
+  //   httpsProxyAgent: new https.Agent() //Optional: Whether to use a custom proxy agent
   // }
   constructor(config) {
     this._region = config.region;
@@ -61,7 +63,8 @@ class SellingPartner {
         user_agent: `amazon-sp-api/${client_version} (Language=Node.js/${node_version}; Platform=${os.type()}/${os.release()})`,
         debug_log: false,
         timeouts: {},
-        retry_remote_timeout: true
+        retry_remote_timeout: true,
+        httpsProxyAgent: new https.Agent()
       },
       config.options
     );
@@ -638,7 +641,7 @@ class SellingPartner {
       token_for_request = this._grantless_tokens[scope];
     } else if (req_params.restricted_data_token) {
       token_for_request = req_params.restricted_data_token;
-    }
+    } 
     let res = await this._request.api(token_for_request, req_params);
     if (options.raw_result) {
       return res;


### PR DESCRIPTION
Currently the code used Node's inbuilt https agent which means you can't pass any proxy information if you are behind a firewall. This change allows the user to pass their own proxy agent using `hpagent` package like this:

```javascript
const { HttpsProxyAgent } = require('hpagent');
const agent = new HttpsProxyAgent({ proxy: 'http://x.x.x.x:zzzz' });
const spClient = new SellingPartner({
  region: "eu",
  options: {
    httpsProxyAgent: agent
  }
});
```