### PR TITLE
Add env-keys for endpoints

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -3,6 +3,7 @@ const utils = require("./utils");
 const TimeoutManager = require("./TimeoutManager");
 const https = require("https");
 const { URL } = require("url");
+const { env } = require("process");
 
 class Request {
   constructor(region, options) {
@@ -14,7 +15,10 @@ class Request {
     };
     this._options = options;
     let sandbox_prefix = this._options.use_sandbox ? "sandbox." : "";
-    this._api_endpoint = `${sandbox_prefix}sellingpartnerapi-${this._region}.amazon.com`;
+    console.log("muh")
+    const apiEnvKey = this._options.use_sandbox ? "SELLING_PARTNER_APP_CLIENT_SANDBOX_ENDPOINT" : "SELLING_PARTNER_APP_CLIENT_ENDPOINT"
+    this._api_endpoint = env[apiEnvKey] || `${sandbox_prefix}sellingpartnerapi-${this._region}.amazon.com`;
+    console.log(this._api_endpoint)
     this._iso_date;
   }
 

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -15,10 +15,8 @@ class Request {
     };
     this._options = options;
     let sandbox_prefix = this._options.use_sandbox ? "sandbox." : "";
-    console.log("muh")
     const apiEnvKey = this._options.use_sandbox ? "SELLING_PARTNER_APP_CLIENT_SANDBOX_ENDPOINT" : "SELLING_PARTNER_APP_CLIENT_ENDPOINT"
     this._api_endpoint = env[apiEnvKey] || `${sandbox_prefix}sellingpartnerapi-${this._region}.amazon.com`;
-    console.log(this._api_endpoint)
     this._iso_date;
   }
 

--- a/lib/SellingPartner.js
+++ b/lib/SellingPartner.js
@@ -568,7 +568,7 @@ class SellingPartner {
   async refreshAccessToken(scope) {
     let res = await this._request.execute({
       method: "POST",
-      url: env.SELLING_PARTNER_APP_CLIENT_AUTH_ENDPOINT,
+      url: env.SELLING_PARTNER_APP_CLIENT_AUTH_ENDPOINT || "https://api.amazon.com/auth/o2/token",
       body: this._constructRefreshAccessTokenBody(scope),
       headers: {
         "Content-Type": "application/json"

--- a/lib/SellingPartner.js
+++ b/lib/SellingPartner.js
@@ -11,6 +11,7 @@ const iconv = require("iconv-lite");
 const client_version = require("../package.json").version;
 const node_version = process.version;
 const os = require("os");
+const { env } = require("process");
 
 // Provide credentials as environment variables OR create a path and file ~/.amzspapi/credentials (located in your user folder)
 // If you don't provide an access_token, the first call to an API endpoint will request them with a TTL of 1 hour
@@ -538,7 +539,7 @@ class SellingPartner {
   async exchange(auth_code) {
     let res = await this._request.execute({
       method: "POST",
-      url: "https://api.amazon.com/auth/o2/token",
+      url: env.SELLING_PARTNER_APP_CLIENT_AUTH_ENDPOINT || "https://api.amazon.com/auth/o2/token",
       body: this._constructExchangeBody(auth_code),
       headers: {
         "Content-Type": "application/json"
@@ -567,7 +568,7 @@ class SellingPartner {
   async refreshAccessToken(scope) {
     let res = await this._request.execute({
       method: "POST",
-      url: "https://api.amazon.com/auth/o2/token",
+      url: env.SELLING_PARTNER_APP_CLIENT_AUTH_ENDPOINT,
       body: this._constructRefreshAccessTokenBody(scope),
       headers: {
         "Content-Type": "application/json"


### PR DESCRIPTION
If you want to run this library behind a reverse-proxy, one need to specify the endpoints manually.
This PR would do that.

This is missing documentation. Let me know if this concept is ok and potentially ready to merge and i'll add documentation.