### PR TITLE
fix: refreshAccessToken typings

### DIFF
--- a/lib/SellingPartner.js
+++ b/lib/SellingPartner.js
@@ -250,7 +250,8 @@ class SellingPartner {
     };
     let valid_scopes = [
       "sellingpartnerapi::notifications",
-      "sellingpartnerapi::migration"
+      "sellingpartnerapi::migration",
+      "sellingpartnerapi::client_credential:rotation"
     ];
     if (scope) {
       // Make sure that scope is valid

--- a/lib/typings/baseTypes.ts
+++ b/lib/typings/baseTypes.ts
@@ -40,3 +40,8 @@ export interface DownloadOptions {
   unzip?: boolean;
   file?: string;
 }
+
+export type Scope =
+  | 'sellingpartnerapi::notifications'
+  | 'sellingpartnerapi::migration'
+  | 'sellingpartnerapi::client_credential:rotation'

--- a/lib/typings/index.d.ts
+++ b/lib/typings/index.d.ts
@@ -453,5 +453,6 @@ declare module "amazon-sp-api" {
     query?: QueryType<TOperation>;
     body?: BodyType<TOperation>;
     options?: ReqOptions;
+    scope?: Scope
   }
 }

--- a/lib/typings/index.d.ts
+++ b/lib/typings/index.d.ts
@@ -127,7 +127,7 @@ declare module "amazon-sp-api" {
     constructor(config: Config);
 
     refreshAccessToken(
-        scope?: 'sellingpartnerapi::notifications' | 'sellingpartnerapi::migration'
+        scope?: 'sellingpartnerapi::notifications' | 'sellingpartnerapi::migration' | 'sellingpartnerapi::client_credential:rotation'
     ): Promise<void>;
 
     exchange(auth_code: string): Promise<any>;

--- a/lib/typings/index.d.ts
+++ b/lib/typings/index.d.ts
@@ -126,7 +126,9 @@ declare module "amazon-sp-api" {
   export class SellingPartner {
     constructor(config: Config);
 
-    refreshAccessToken(): Promise<void>;
+    refreshAccessToken(
+        scope?: 'sellingpartnerapi::notifications' | 'sellingpartnerapi::migration'
+    ): Promise<void>;
 
     exchange(auth_code: string): Promise<any>;
 

--- a/lib/typings/index.d.ts
+++ b/lib/typings/index.d.ts
@@ -29,7 +29,7 @@ import {
   GetFeedsQuery,
   GetFeedsResponse
 } from "./operations/feeds";
-import { Config, DownloadOptions } from "./baseTypes";
+import { Config, DownloadOptions, Scope } from "./baseTypes";
 import {
   ConfirmPreorderPath,
   ConfirmPreorderQuery,
@@ -127,7 +127,7 @@ declare module "amazon-sp-api" {
     constructor(config: Config);
 
     refreshAccessToken(
-        scope?: 'sellingpartnerapi::notifications' | 'sellingpartnerapi::migration' | 'sellingpartnerapi::client_credential:rotation'
+        scope?: Scope
     ): Promise<void>;
 
     exchange(auth_code: string): Promise<any>;


### PR DESCRIPTION
@amz-tools You seem to document this functionality in https://github.com/amz-tools/amazon-sp-api/blob/a67512441db3e12473b02be7d4944c67a182b90f/README.md?plain=1#L525 but it doesnt seem reflected in code