### PR TITLE
fix(data-kiosk): incorrect url for data kiosk documents

### DIFF
--- a/lib/resources/versions/data_kiosk/dataKiosk_2023-11-15.js
+++ b/lib/resources/versions/data_kiosk/dataKiosk_2023-11-15.js
@@ -54,7 +54,7 @@ module.exports = {
       });
       return Object.assign(req_params, {
         method: "GET",
-        api_path: "/dataKiosk/2023-11-15/queries/" + req_params.path.documentId,
+        api_path: "/dataKiosk/2023-11-15/documents/" + req_params.path.documentId,
         restore_rate: 60
       });
     }


### PR DESCRIPTION
This pull request includes a change to the `lib/resources/versions/data_kiosk/dataKiosk_2023-11-15.js` file to update the API path used in the `req_params` object.

SP API Documentation: https://developer-docs.amazon.com/sp-api/docs/data-kiosk-api-v2023-11-15-reference#get-datakiosk2023-11-15documentsdocumentid

* [`lib/resources/versions/data_kiosk/dataKiosk_2023-11-15.js`](diffhunk://#diff-0427c60a56fcd5a4c8049212201a5ba6f7ee254d9ed3ec62e348207a5703cc87L57-R57): Changed the `api_path` from `/dataKiosk/2023-11-15/queries/` to `/dataKiosk/2023-11-15/documents/` to correct the endpoint being accessed.