### PR TITLE
Fix typescript error

### DIFF
--- a/lib/typings/operations/reports.ts
+++ b/lib/typings/operations/reports.ts
@@ -242,7 +242,7 @@ interface ReportOptions {
   [key: string]: string;
 }
 
-interface Report {
+export interface Report {
   marketplaceIds?: string[];
   reportId: string;
   reportType: ReportType;


### PR DESCRIPTION
fixing the following typescript error:

Return type of public method from exported class has or is using name 'Report' from external module "F:/.../node_modules/amazon-sp-api/lib/typings/operations/reports" but cannot be named.