### PR TITLE
Fix typescript error

### DIFF
--- a/lib/typings/operations/feeds.ts
+++ b/lib/typings/operations/feeds.ts
@@ -86,6 +86,6 @@ export interface GetFeedDocumentResponse extends BaseResponse {
   payload?: FeedDocument;
 }
 
-interface FeedDocument extends CreateFeedDocumentResult {
+export interface FeedDocument extends CreateFeedDocumentResult {
   compressionAlgorithm?: "GZIP";
 }


### PR DESCRIPTION
fixing the following typescript error:

Return type of public method from exported class has or is using name 'FeedDocument' from external module "F:/.../node_modules/amazon-sp-api/lib/typings/operations/feeds" but cannot be named.