### PR TITLE
Apply timeout options to access_token refresh call

### DIFF
--- a/lib/SellingPartner.js
+++ b/lib/SellingPartner.js
@@ -66,6 +66,7 @@ class SellingPartner {
       },
       config.options
     );
+    this._current_call_timeouts = this._options.timeouts;
     this._endpoints_versions = this._validateEndpointsVersions(
       Object.assign({}, config.endpoints_versions)
     );
@@ -571,7 +572,8 @@ class SellingPartner {
       body: this._constructRefreshAccessTokenBody(scope),
       headers: {
         "Content-Type": "application/json"
-      }
+      },
+      timeouts: this._current_call_timeouts
     });
     let json_res;
     try {
@@ -656,6 +658,8 @@ class SellingPartner {
       this._options.timeouts,
       options.timeouts
     );
+    // Store timeouts defined for the current call to use for any other requests we may need to make e.g. refresh access token
+    this._current_call_timeouts = req_params.timeouts;
     // Scope will only be defined for grantless operations
     let scope = req_params.scope;
     this._validateOperationAllowance(scope);


### PR DESCRIPTION
Thank you for incorporating my earlier pull request #148 to add timeout options. We have updated our production code to use the timeout options that the library now supports and have encountered an issue which this new PR should fix:

When timeout options have been specified for an API call, it is still currently possible for the call to take longer or even hang up. This happens when the current access_token is not valid. In this case, the library makes a http request to get a new access_token via the refreshToken call. If this request does not complete the code can hang. This is rare but we have observed it in production code.

This pull request stores the timeout options for the current call in a new SellingPartner object property. The current call timeout options are then used for any calls to refreshToken, ensuring that any call to get a new access_token will also time out with an error if no response is received within the specified timeout.

fixes #300

