### PR TITLE
feat(catalogItems): add response type

### DIFF
--- a/lib/typings/index.d.ts
+++ b/lib/typings/index.d.ts
@@ -84,6 +84,8 @@ import {
   GetCatalogItemPath,
   GetCatalogItemQuery,
   GetCatalogItemResponse,
+  SearchCatalogItemsQuery,
+  SearchCatalogItemsResponse,
   ListCatalogCategoriesQuery,
   ListCatalogCategoriesResponse
 } from './operations/catalogItems';
@@ -150,6 +152,7 @@ declare module 'amazon-sp-api' {
 
   type Operation =
     | 'getCatalogItem'
+    | 'searchCatalogItems'
     | 'listCatalogCategories'
     | 'getItemEligibilityPreview'
     | 'getInventorySummaries'
@@ -285,7 +288,9 @@ declare module 'amazon-sp-api' {
                                                                                           ? SearchProductTypesResponse
                                                                                           : TOperation extends 'searchDefinitionsProductTypes'
                                                                                             ? SearchDefinitionsProductTypesResponse
-                                                                                            : any;
+                                                                                            : TOperation extends 'searchCatalogItems'
+                                                                                              ? SearchCatalogItemsResponse
+                                                                                              : any;
 
   type QueryType<TOperation extends Operation> = TOperation extends 'getCatalogItem'
     ? GetCatalogItemQuery
@@ -336,7 +341,9 @@ declare module 'amazon-sp-api' {
                                                 ? SearchProductTypesQuery
                                                 : TOperation extends 'searchDefinitionsProductTypes'
                                                   ? SearchDefinitionsProductTypesQuery
-                                                  : any;
+                                                  : TOperation extends 'searchCatalogItems'
+                                                    ? SearchCatalogItemsQuery
+                                                    : any;
 
   type PathType<TOperation extends Operation> = TOperation extends 'getCatalogItem'
     ? GetCatalogItemPath

--- a/lib/typings/operations/catalogItems.ts
+++ b/lib/typings/operations/catalogItems.ts
@@ -24,16 +24,7 @@ export interface SearchCatalogItemsResponse extends BaseResponse {
   payload: ItemSearchResults;
 }
 
-enum IdentifiersType {
-  'ASIN',
-  'EAN',
-  'GTIN',
-  'ISBN',
-  'JAN',
-  'MINSAN',
-  'SKU',
-  'UPC'
-}
+type IdentifiersType = 'ASIN' | 'EAN' | 'GTIN' | 'ISBN' | 'JAN' | 'MINSAN' | 'SKU' | 'UPC';
 
 export interface GetCatalogItemQuery {
   marketplaceIds: string[];
@@ -41,18 +32,17 @@ export interface GetCatalogItemQuery {
   locale?: string;
 }
 
-enum IncludedData {
-  'attributes',
-  'classifications',
-  'dimensions',
-  'identifiers',
-  'images',
-  'productTypes',
-  'relationships',
-  'salesRanks',
-  'summaries',
-  'vendorDetails'
-}
+type IncludedData =
+  | 'attributes'
+  | 'classifications'
+  | 'dimensions'
+  | 'identifiers'
+  | 'images'
+  | 'productTypes'
+  | 'relationships'
+  | 'salesRanks'
+  | 'summaries'
+  | 'vendorDetails';
 
 export interface GetCatalogItemPath {
   asin: string;
@@ -162,18 +152,7 @@ interface ItemImage {
   width: number;
 }
 
-enum Variant {
-  'MAIN',
-  'PT01',
-  'PT02',
-  'PT03',
-  'PT04',
-  'PT05',
-  'PT06',
-  'PT07',
-  'PT08',
-  'SWCH'
-}
+type Variant = 'MAIN' | 'PT01' | 'PT02' | 'PT03' | 'PT04' | 'PT05' | 'PT06' | 'PT07' | 'PT08' | 'SWCH';
 
 interface ItemProductTypes {
   marketplaceId?: string;
@@ -197,10 +176,7 @@ interface ItemVariationTheme {
   theme?: string;
 }
 
-enum Type {
-  'VARIATION',
-  'PACKAGE_HIERARCHY'
-}
+type Type = 'VARIATION' | 'PACKAGE_HIERARCHY';
 
 interface ItemSalesRanks {
   marketplaceId: string;
@@ -261,12 +237,7 @@ interface ItemContributorRole {
   value: string;
 }
 
-enum Iteminterfaceification {
-  'BASE_PRODUCT',
-  'OTHER',
-  'PRODUCT_BUNDLE',
-  'VARIATION_PARENT'
-}
+type Iteminterfaceification = 'BASE_PRODUCT' | 'OTHER' | 'PRODUCT_BUNDLE' | 'VARIATION_PARENT';
 
 interface ItemVendorDetails {
   marketplaceId: string;
@@ -284,18 +255,17 @@ interface ItemVendorDetailsCategory {
   value?: string;
 }
 
-enum ReplenishmentCategory {
-  'ALLOCATED',
-  'BASIC_REPLENISHMENT',
-  'IN_SEASON',
-  'LIMITED_REPLENISHMENT',
-  'MANUFACTURER_OUT_OF_STOCK',
-  'NEW_PRODUCT',
-  'NON_REPLENISHABLE',
-  'NON_STOCKUPABLE',
-  'OBSOLETE',
-  'PLANNED_REPLENISHMENT'
-}
+type ReplenishmentCategory =
+  | 'ALLOCATED'
+  | 'BASIC_REPLENISHMENT'
+  | 'IN_SEASON'
+  | 'LIMITED_REPLENISHMENT'
+  | 'MANUFACTURER_OUT_OF_STOCK'
+  | 'NEW_PRODUCT'
+  | 'NON_REPLENISHABLE'
+  | 'NON_STOCKUPABLE'
+  | 'OBSOLETE'
+  | 'PLANNED_REPLENISHMENT';
 
 /**
  *

--- a/lib/typings/operations/catalogItems.ts
+++ b/lib/typings/operations/catalogItems.ts
@@ -11,7 +11,7 @@ export interface GetCatalogItemPath {
 }
 
 export interface GetCatalogItemResponse extends BaseResponse {
-  payload?: any;
+  payload?: ItemSearchResults;
 }
 
 export interface ListCatalogCategoriesQuery {
@@ -207,4 +207,240 @@ interface Relationship {
 interface SalesRank {
   ProductCategoryId?: string;
   Rank?: number;
+}
+
+
+/**
+ * The response schema for the searchCatalogItems operation.
+ * GET /catalog/2022-04-01/items
+ * Operation: searchCatalogItems
+ */
+export interface ItemSearchResults {
+  numberOfResults: number;
+  pagination: Pagination;
+  refinements: Refinements;
+  items: Item[];
+}
+
+// !== from Pagination baseTypes
+interface Pagination {
+  nextToken?: string;
+  previousToken?: string;
+}
+
+interface Refinements {
+  brands: BrandRefinement[];
+  interfaceifications: interfaceificationRefinement[];
+}
+
+interface Item {
+  asin: string;
+  attributes?: ItemAttributes;
+  interfaceifications?: ItemBrowseinterfaceifications;
+  dimensions?: ItemDimensions;
+  identifiers?: ItemIdentifiers[];
+  images?: ItemImages[];
+  productTypes?: ItemProductTypes[];
+  relationships?: ItemRelationships[];
+  salesRanks: ItemSalesRanks[];
+  summaries: ItemSummaries[];
+  vendorDetails?: ItemVendorDetails;
+}
+
+interface BrandRefinement {
+  numberOfResults: number;
+  brandName: string;
+}
+
+interface interfaceificationRefinement {
+  numberOfResults: number;
+  displayName: string;
+  interfaceificationId: string;
+}
+
+interface ItemAttributes {
+  displayName: string;
+  interfaceificationId: string;
+  parent?: ItemBrowseinterfaceification;
+}
+
+interface ItemBrowseinterfaceifications {
+  displayName: string;
+  interfaceificationId: string;
+  parent?: ItemBrowseinterfaceifications;
+}
+
+interface ItemDimensions {
+  marketplaceId: string;
+  item: Dimensions;
+  package: Dimensions;
+}
+
+interface Dimensions {
+  height: Dimension;
+  length: Dimension;
+  weight: Dimension;
+  width: Dimension;
+}
+
+interface Dimension {
+  unit: string;
+  value: number;
+}
+
+interface ItemIdentifiers {
+  marketplaceId: string;
+  identifiers: ItemIdentifier[];
+}
+
+interface ItemIdentifier {
+  identifierType: string;
+  identifier: string;
+}
+
+interface ItemImages {
+  marketplaceId: string;
+  images: ItemImage[];
+}
+
+interface ItemImage {
+  variant: Variant;
+  link: string;
+  height: number;
+  width: number;
+}
+
+enum Variant {
+  'MAIN',
+  'PT01',
+  'PT02',
+  'PT03',
+  'PT04',
+  'PT05',
+  'PT06',
+  'PT07',
+  'PT08',
+  'SWCH',
+}
+
+interface ItemProductTypes {
+  marketplaceId?: string;
+  productType?: string;
+}
+
+interface ItemRelationships {
+  marketplaceId: string;
+  relationships: ItemRelationship[];
+}
+
+interface ItemRelationship {
+  childAsins?: string[];
+  parentAsins?: string[];
+  variationTheme?: ItemVariationTheme;
+  type: Type;
+}
+
+interface ItemVariationTheme {
+  attributes?: string[];
+  theme?: string;
+}
+
+enum Type {
+  'VARIATION',
+  'PACKAGE_HIERARCHY',
+}
+
+interface ItemSalesRanks {
+  marketplaceId: string;
+  interfaceificationRanks: IteminterfaceificationSalesRank[];
+  displayGroupRanks: ItemDisplayGroupSalesRank[];
+}
+
+interface IteminterfaceificationSalesRank {
+  interfaceificationId: string;
+  title: string;
+  link: string;
+  rank: number;
+}
+
+interface ItemDisplayGroupSalesRank {
+  websiteDisplayGroup: string;
+  title: string;
+  link: string;
+  rank: number;
+}
+
+interface ItemSummaries {
+  marketplaceId: string;
+  adultProduct?: boolean;
+  autographed?: boolean;
+  brand?: string;
+  browseinterfaceification?: ItemBrowseinterfaceification;
+  color?: string;
+  contributors?: ItemContributor[];
+  iteminterfaceification?: Iteminterfaceification;
+  itemName: string;
+  manufacturer?: string;
+  memorabilia?: boolean;
+  modelNumber?: string;
+  packageQuantity?: number;
+  partNumber?: string;
+  releaseDate?: string;
+  size?: string;
+  style?: string;
+  tradeInEligible?: boolean;
+  websiteDisplayGroup?: string;
+  websiteDisplayGroupName?: string;
+}
+
+interface ItemBrowseinterfaceification {
+  displayName: string;
+  interfaceificationId: string;
+  parent?: ItemBrowseinterfaceification;
+}
+
+interface ItemContributor {
+  role: ItemContributorRole;
+  value: string;
+}
+
+interface ItemContributorRole {
+  displayName?: string;
+  value: string;
+}
+
+enum Iteminterfaceification {
+  'BASE_PRODUCT',
+  'OTHER',
+  'PRODUCT_BUNDLE',
+  'VARIATION_PARENT',
+}
+
+interface ItemVendorDetails {
+  marketplaceId: string;
+  brandCode?: string;
+  manufacturerCode?: string;
+  manufacturerCodeParent?: string;
+  productCategory?: ItemVendorDetailsCategory;
+  productGroup?: string;
+  productSubcategory?: ItemVendorDetailsCategory;
+  replenishmentCategory?: ReplenishmentCategory;
+}
+
+interface ItemVendorDetailsCategory {
+  displayName?: string;
+  value?: string;
+}
+
+enum ReplenishmentCategory {
+  'ALLOCATED',
+  'BASIC_REPLENISHMENT',
+  'IN_SEASON',
+  'LIMITED_REPLENISHMENT',
+  'MANUFACTURER_OUT_OF_STOCK',
+  'NEW_PRODUCT',
+  'NON_REPLENISHABLE',
+  'NON_STOCKUPABLE',
+  'OBSOLETE',
+  'PLANNED_REPLENISHMENT',
 }

--- a/lib/typings/operations/catalogItems.ts
+++ b/lib/typings/operations/catalogItems.ts
@@ -1,9 +1,57 @@
 import type {BaseResponse} from '../baseTypes';
 
-export interface GetCatalogItemQuery {
-  includedData?: string;
-  locale?: string;
+/**
+ *  2022-04-01 searchCatalogItems and getCatalogItem
+ *  V0 listCatalogItems (deprecated in 2022 but still in use)
+ */
+
+export interface SearchCatalogItemsQuery {
+  identifiers?: string;
+  identifiersType?: IdentifiersType;
   marketplaceIds: string[];
+  includedData?: IncludedData[];
+  locale?: string;
+  sellerId?: string;
+  keywords?: string[];
+  brandNames?: string[];
+  classificationIds?: string[];
+  pageSize?: number;
+  pageToken?: string;
+  keywordsLocale?: string;
+}
+
+export interface SearchCatalogItemsResponse extends BaseResponse {
+  payload: ItemSearchResults;
+}
+
+enum IdentifiersType {
+  'ASIN',
+  'EAN',
+  'GTIN',
+  'ISBN',
+  'JAN',
+  'MINSAN',
+  'SKU',
+  'UPC'
+}
+
+export interface GetCatalogItemQuery {
+  marketplaceIds: string[];
+  includedData?: IncludedData[];
+  locale?: string;
+}
+
+enum IncludedData {
+  'attributes',
+  'classifications',
+  'dimensions',
+  'identifiers',
+  'images',
+  'productTypes',
+  'relationships',
+  'salesRanks',
+  'summaries',
+  'vendorDetails'
 }
 
 export interface GetCatalogItemPath {
@@ -11,8 +59,251 @@ export interface GetCatalogItemPath {
 }
 
 export interface GetCatalogItemResponse extends BaseResponse {
-  payload?: ItemSearchResults;
+  payload?: Item;
 }
+
+/**
+ * The response schema for the searchCatalogItems operation.
+ * GET /catalog/2022-04-01/items
+ * Operation: searchCatalogItems
+ */
+export interface ItemSearchResults {
+  numberOfResults: number;
+  pagination: Pagination;
+  refinements: Refinements;
+  items: Item[];
+}
+
+// !== from Pagination baseTypes
+interface Pagination {
+  nextToken?: string;
+  previousToken?: string;
+}
+
+interface Refinements {
+  brands: BrandRefinement[];
+  interfaceifications: interfaceificationRefinement[];
+}
+
+interface Item {
+  asin: string;
+  attributes?: ItemAttributes;
+  interfaceifications?: ItemBrowseinterfaceifications;
+  dimensions?: ItemDimensions;
+  identifiers?: ItemIdentifiers[];
+  images?: ItemImages[];
+  productTypes?: ItemProductTypes[];
+  relationships?: ItemRelationships[];
+  salesRanks: ItemSalesRanks[];
+  summaries: ItemSummaries[];
+  vendorDetails?: ItemVendorDetails;
+}
+
+interface BrandRefinement {
+  numberOfResults: number;
+  brandName: string;
+}
+
+interface interfaceificationRefinement {
+  numberOfResults: number;
+  displayName: string;
+  interfaceificationId: string;
+}
+
+interface ItemAttributes {
+  displayName: string;
+  interfaceificationId: string;
+  parent?: ItemBrowseinterfaceification;
+}
+
+interface ItemBrowseinterfaceifications {
+  displayName: string;
+  interfaceificationId: string;
+  parent?: ItemBrowseinterfaceifications;
+}
+
+interface ItemDimensions {
+  marketplaceId: string;
+  item: Dimensions;
+  package: Dimensions;
+}
+
+interface Dimensions {
+  height: Dimension;
+  length: Dimension;
+  weight: Dimension;
+  width: Dimension;
+}
+
+interface Dimension {
+  unit: string;
+  value: number;
+}
+
+interface ItemIdentifiers {
+  marketplaceId: string;
+  identifiers: ItemIdentifier[];
+}
+
+interface ItemIdentifier {
+  identifierType: string;
+  identifier: string;
+}
+
+interface ItemImages {
+  marketplaceId: string;
+  images: ItemImage[];
+}
+
+interface ItemImage {
+  variant: Variant;
+  link: string;
+  height: number;
+  width: number;
+}
+
+enum Variant {
+  'MAIN',
+  'PT01',
+  'PT02',
+  'PT03',
+  'PT04',
+  'PT05',
+  'PT06',
+  'PT07',
+  'PT08',
+  'SWCH'
+}
+
+interface ItemProductTypes {
+  marketplaceId?: string;
+  productType?: string;
+}
+
+interface ItemRelationships {
+  marketplaceId: string;
+  relationships: ItemRelationship[];
+}
+
+interface ItemRelationship {
+  childAsins?: string[];
+  parentAsins?: string[];
+  variationTheme?: ItemVariationTheme;
+  type: Type;
+}
+
+interface ItemVariationTheme {
+  attributes?: string[];
+  theme?: string;
+}
+
+enum Type {
+  'VARIATION',
+  'PACKAGE_HIERARCHY'
+}
+
+interface ItemSalesRanks {
+  marketplaceId: string;
+  interfaceificationRanks: IteminterfaceificationSalesRank[];
+  displayGroupRanks: ItemDisplayGroupSalesRank[];
+}
+
+interface IteminterfaceificationSalesRank {
+  interfaceificationId: string;
+  title: string;
+  link: string;
+  rank: number;
+}
+
+interface ItemDisplayGroupSalesRank {
+  websiteDisplayGroup: string;
+  title: string;
+  link: string;
+  rank: number;
+}
+
+interface ItemSummaries {
+  marketplaceId: string;
+  adultProduct?: boolean;
+  autographed?: boolean;
+  brand?: string;
+  browseinterfaceification?: ItemBrowseinterfaceification;
+  color?: string;
+  contributors?: ItemContributor[];
+  iteminterfaceification?: Iteminterfaceification;
+  itemName: string;
+  manufacturer?: string;
+  memorabilia?: boolean;
+  modelNumber?: string;
+  packageQuantity?: number;
+  partNumber?: string;
+  releaseDate?: string;
+  size?: string;
+  style?: string;
+  tradeInEligible?: boolean;
+  websiteDisplayGroup?: string;
+  websiteDisplayGroupName?: string;
+}
+
+interface ItemBrowseinterfaceification {
+  displayName: string;
+  interfaceificationId: string;
+  parent?: ItemBrowseinterfaceification;
+}
+
+interface ItemContributor {
+  role: ItemContributorRole;
+  value: string;
+}
+
+interface ItemContributorRole {
+  displayName?: string;
+  value: string;
+}
+
+enum Iteminterfaceification {
+  'BASE_PRODUCT',
+  'OTHER',
+  'PRODUCT_BUNDLE',
+  'VARIATION_PARENT'
+}
+
+interface ItemVendorDetails {
+  marketplaceId: string;
+  brandCode?: string;
+  manufacturerCode?: string;
+  manufacturerCodeParent?: string;
+  productCategory?: ItemVendorDetailsCategory;
+  productGroup?: string;
+  productSubcategory?: ItemVendorDetailsCategory;
+  replenishmentCategory?: ReplenishmentCategory;
+}
+
+interface ItemVendorDetailsCategory {
+  displayName?: string;
+  value?: string;
+}
+
+enum ReplenishmentCategory {
+  'ALLOCATED',
+  'BASIC_REPLENISHMENT',
+  'IN_SEASON',
+  'LIMITED_REPLENISHMENT',
+  'MANUFACTURER_OUT_OF_STOCK',
+  'NEW_PRODUCT',
+  'NON_REPLENISHABLE',
+  'NON_STOCKUPABLE',
+  'OBSOLETE',
+  'PLANNED_REPLENISHMENT'
+}
+
+/**
+ *
+ *
+ *  V0 DEPRECATED BY AMAZON BUT STILL IN USE
+ *
+ *
+ */
 
 export interface ListCatalogCategoriesQuery {
   MarketplaceId: string;
@@ -207,240 +498,4 @@ interface Relationship {
 interface SalesRank {
   ProductCategoryId?: string;
   Rank?: number;
-}
-
-
-/**
- * The response schema for the searchCatalogItems operation.
- * GET /catalog/2022-04-01/items
- * Operation: searchCatalogItems
- */
-export interface ItemSearchResults {
-  numberOfResults: number;
-  pagination: Pagination;
-  refinements: Refinements;
-  items: Item[];
-}
-
-// !== from Pagination baseTypes
-interface Pagination {
-  nextToken?: string;
-  previousToken?: string;
-}
-
-interface Refinements {
-  brands: BrandRefinement[];
-  interfaceifications: interfaceificationRefinement[];
-}
-
-interface Item {
-  asin: string;
-  attributes?: ItemAttributes;
-  interfaceifications?: ItemBrowseinterfaceifications;
-  dimensions?: ItemDimensions;
-  identifiers?: ItemIdentifiers[];
-  images?: ItemImages[];
-  productTypes?: ItemProductTypes[];
-  relationships?: ItemRelationships[];
-  salesRanks: ItemSalesRanks[];
-  summaries: ItemSummaries[];
-  vendorDetails?: ItemVendorDetails;
-}
-
-interface BrandRefinement {
-  numberOfResults: number;
-  brandName: string;
-}
-
-interface interfaceificationRefinement {
-  numberOfResults: number;
-  displayName: string;
-  interfaceificationId: string;
-}
-
-interface ItemAttributes {
-  displayName: string;
-  interfaceificationId: string;
-  parent?: ItemBrowseinterfaceification;
-}
-
-interface ItemBrowseinterfaceifications {
-  displayName: string;
-  interfaceificationId: string;
-  parent?: ItemBrowseinterfaceifications;
-}
-
-interface ItemDimensions {
-  marketplaceId: string;
-  item: Dimensions;
-  package: Dimensions;
-}
-
-interface Dimensions {
-  height: Dimension;
-  length: Dimension;
-  weight: Dimension;
-  width: Dimension;
-}
-
-interface Dimension {
-  unit: string;
-  value: number;
-}
-
-interface ItemIdentifiers {
-  marketplaceId: string;
-  identifiers: ItemIdentifier[];
-}
-
-interface ItemIdentifier {
-  identifierType: string;
-  identifier: string;
-}
-
-interface ItemImages {
-  marketplaceId: string;
-  images: ItemImage[];
-}
-
-interface ItemImage {
-  variant: Variant;
-  link: string;
-  height: number;
-  width: number;
-}
-
-enum Variant {
-  'MAIN',
-  'PT01',
-  'PT02',
-  'PT03',
-  'PT04',
-  'PT05',
-  'PT06',
-  'PT07',
-  'PT08',
-  'SWCH',
-}
-
-interface ItemProductTypes {
-  marketplaceId?: string;
-  productType?: string;
-}
-
-interface ItemRelationships {
-  marketplaceId: string;
-  relationships: ItemRelationship[];
-}
-
-interface ItemRelationship {
-  childAsins?: string[];
-  parentAsins?: string[];
-  variationTheme?: ItemVariationTheme;
-  type: Type;
-}
-
-interface ItemVariationTheme {
-  attributes?: string[];
-  theme?: string;
-}
-
-enum Type {
-  'VARIATION',
-  'PACKAGE_HIERARCHY',
-}
-
-interface ItemSalesRanks {
-  marketplaceId: string;
-  interfaceificationRanks: IteminterfaceificationSalesRank[];
-  displayGroupRanks: ItemDisplayGroupSalesRank[];
-}
-
-interface IteminterfaceificationSalesRank {
-  interfaceificationId: string;
-  title: string;
-  link: string;
-  rank: number;
-}
-
-interface ItemDisplayGroupSalesRank {
-  websiteDisplayGroup: string;
-  title: string;
-  link: string;
-  rank: number;
-}
-
-interface ItemSummaries {
-  marketplaceId: string;
-  adultProduct?: boolean;
-  autographed?: boolean;
-  brand?: string;
-  browseinterfaceification?: ItemBrowseinterfaceification;
-  color?: string;
-  contributors?: ItemContributor[];
-  iteminterfaceification?: Iteminterfaceification;
-  itemName: string;
-  manufacturer?: string;
-  memorabilia?: boolean;
-  modelNumber?: string;
-  packageQuantity?: number;
-  partNumber?: string;
-  releaseDate?: string;
-  size?: string;
-  style?: string;
-  tradeInEligible?: boolean;
-  websiteDisplayGroup?: string;
-  websiteDisplayGroupName?: string;
-}
-
-interface ItemBrowseinterfaceification {
-  displayName: string;
-  interfaceificationId: string;
-  parent?: ItemBrowseinterfaceification;
-}
-
-interface ItemContributor {
-  role: ItemContributorRole;
-  value: string;
-}
-
-interface ItemContributorRole {
-  displayName?: string;
-  value: string;
-}
-
-enum Iteminterfaceification {
-  'BASE_PRODUCT',
-  'OTHER',
-  'PRODUCT_BUNDLE',
-  'VARIATION_PARENT',
-}
-
-interface ItemVendorDetails {
-  marketplaceId: string;
-  brandCode?: string;
-  manufacturerCode?: string;
-  manufacturerCodeParent?: string;
-  productCategory?: ItemVendorDetailsCategory;
-  productGroup?: string;
-  productSubcategory?: ItemVendorDetailsCategory;
-  replenishmentCategory?: ReplenishmentCategory;
-}
-
-interface ItemVendorDetailsCategory {
-  displayName?: string;
-  value?: string;
-}
-
-enum ReplenishmentCategory {
-  'ALLOCATED',
-  'BASIC_REPLENISHMENT',
-  'IN_SEASON',
-  'LIMITED_REPLENISHMENT',
-  'MANUFACTURER_OUT_OF_STOCK',
-  'NEW_PRODUCT',
-  'NON_REPLENISHABLE',
-  'NON_STOCKUPABLE',
-  'OBSOLETE',
-  'PLANNED_REPLENISHMENT',
 }

--- a/lib/typings/operations/feeds.ts
+++ b/lib/typings/operations/feeds.ts
@@ -1,12 +1,6 @@
 import type {BaseResponse} from '../baseTypes';
 
-enum ProcessingStatus {
-  InQueue = 'IN_QUEUE',
-  InProgress = 'IN_PROGRESS',
-  Done = 'DONE',
-  Cancelled = 'CANCELLED',
-  Fatal = 'FATAL'
-}
+type ProcessingStatus = 'IN_QUEUE' | 'IN_PROGRESS' | 'DONE' | 'CANCELLED' | 'FATAL';
 
 export interface GetFeedsQuery {
   feedTypes?: string[];


### PR DESCRIPTION
Idk how to differentiate the two types of `searchCatalogItems` (2020 and 2022)
btw this is the 2022 version