### PR TITLE
Fix the website url.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "test": "mocha --config ./test/.mocharc.js",
     "format": "npx prettier --write ."
   },
-  "homepage": "https:/getarthy.com",
+  "homepage": "https://getarthy.com",
   "types": "./lib/typings/index.d.ts"
 }


### PR DESCRIPTION
Just noticed on the npm page that the website link does not work.

There was a typo in the url. 😄 