### PR TITLE
Add customer feedback endpoint

### DIFF
--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -7,6 +7,7 @@ module.exports = {
   ...require('./resources/appIntegrations'),
   ...require('./resources/applicationManagement'),
   ...require('./resources/catalogItems'),
+  ...require('./resources/customerFeedback'),
   ...require('./resources/dataKiosk'),
   ...require('./resources/easyShip'),
   ...require('./resources/fbaInboundEligibility'),

--- a/lib/resources/customerFeedback.js
+++ b/lib/resources/customerFeedback.js
@@ -1,0 +1,15 @@
+module.exports = {
+  customerFeedback: {
+    __versions: ['2024-06-01'],
+    __operations: [
+      'getItemReviewTopics',
+      'getItemBrowseNode',
+      'getBrowseNodeReviewTopics',
+      'getItemReviewTrends',
+      'getBrowseNodeReviewTrends',
+      'getBrowseNodeReturnTopics',
+      'getBrowseNodeReturnTrends'
+    ],
+    ...require('./versions/customer_feedback/customerFeedback_2024-06-01')
+  }
+};

--- a/lib/resources/versions/customer_feedback/customerFeedback_2024-06-01.js
+++ b/lib/resources/versions/customer_feedback/customerFeedback_2024-06-01.js
@@ -1,0 +1,110 @@
+const utils = require('../../../utils');
+
+module.exports = {
+  '2024-06-01': {
+    getItemReviewTopics: (req_params) => {
+      req_params = utils.checkAndEncodeParams(req_params, {
+        path: {
+          asin: {
+            type: 'string'
+          }
+        }
+      });
+      return Object.assign(req_params, {
+        method: 'GET',
+        api_path: '/customerFeedback/2024-06-01/items/' + req_params.path.asin + '/reviews/topics',
+        restore_rate: 0.5
+      });
+    },
+
+    getItemBrowseNode: (req_params) => {
+      req_params = utils.checkAndEncodeParams(req_params, {
+        path: {
+          asin: {
+            type: 'string'
+          }
+        }
+      });
+      return Object.assign(req_params, {
+        method: 'GET',
+        api_path: '/customerFeedback/2024-06-01/items/' + req_params.path.asin + '/browseNode',
+        restore_rate: 0.5
+      });
+    },
+
+    getBrowseNodeReviewTopics: (req_params) => {
+      req_params = utils.checkAndEncodeParams(req_params, {
+        path: {
+          browseNodeId: {
+            type: 'string'
+          }
+        }
+      });
+      return Object.assign(req_params, {
+        method: 'GET',
+        api_path: '/customerFeedback/2024-06-01/browseNodes/' + req_params.path.browseNodeId + '/reviews/topics',
+        restore_rate: 0.5
+      });
+    },
+
+    getItemReviewTrends: (req_params) => {
+      req_params = utils.checkAndEncodeParams(req_params, {
+        path: {
+          asin: {
+            type: 'string'
+          }
+        }
+      });
+      return Object.assign(req_params, {
+        method: 'GET',
+        api_path: '/customerFeedback/2024-06-01/items/' + req_params.path.asin + '/reviews/trends',
+        restore_rate: 0.5
+      });
+    },
+
+    getBrowseNodeReviewTrends: (req_params) => {
+      req_params = utils.checkAndEncodeParams(req_params, {
+        path: {
+          browseNodeId: {
+            type: 'string'
+          }
+        }
+      });
+      return Object.assign(req_params, {
+        method: 'GET',
+        api_path: '/customerFeedback/2024-06-01/browseNodes/' + req_params.path.browseNodeId + '/reviews/trends',
+        restore_rate: 0.5
+      });
+    },
+
+    getBrowseNodeReturnTopics: (req_params) => {
+      req_params = utils.checkAndEncodeParams(req_params, {
+        path: {
+          browseNodeId: {
+            type: 'string'
+          }
+        }
+      });
+      return Object.assign(req_params, {
+        method: 'GET',
+        api_path: '/customerFeedback/2024-06-01/browseNodes/' + req_params.path.browseNodeId + '/returns/topics',
+        restore_rate: 0.5
+      });
+    },
+
+    getBrowseNodeReturnTrends: (req_params) => {
+      req_params = utils.checkAndEncodeParams(req_params, {
+        path: {
+          browseNodeId: {
+            type: 'string'
+          }
+        }
+      });
+      return Object.assign(req_params, {
+        method: 'GET',
+        api_path: '/customerFeedback/2024-06-01/browseNodes/' + req_params.path.browseNodeId + '/returns/trends',
+        restore_rate: 0.5
+      });
+    }
+  }
+};


### PR DESCRIPTION
I'm not sure about `restore_rate`, it's not mentioned in docs, but new endpoints work
https://developer-docs.amazon.com/sp-api/reference/customer-feedback-v2024-06-01